### PR TITLE
adding support for execution option in Terms Filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Prefix multiple keys.
 
 Search multiple key=>value terms.
 
-### Filter.terms(**kwargs)
+### Filter.terms(execution='plain', **kwargs)
 
 Search multiple key=>[values] terms.
 

--- a/elasticquery/filter_query.py
+++ b/elasticquery/filter_query.py
@@ -62,10 +62,19 @@ class Filter(object):
         }
 
     @classmethod
-    def terms(self, **kwargs):
-        return self.type, None, {
-            'terms': kwargs
-        }
+    def terms(self, execution='plain', **kwargs):
+        if self.type == 'filter':
+            kwargs.update({
+                'execution': execution
+            })
+
+            return self.type, None, {
+                'terms': kwargs
+            }
+        else:
+            return self.type, None, {
+                'terms': kwargs,
+            }
 
     @classmethod
     def match(self, **kwargs):

--- a/test.py
+++ b/test.py
@@ -59,9 +59,15 @@ FILTERS = {
             'field_name1': 'value_name1'
         }
     },
-    'TERMS': {
+    'FILTER_TERMS': {
         'terms': {
-            'field_name1': ['value_name1', 'value_name2']
+            'field_name1': ['value_name1', 'value_name2'],
+            'execution': 'bool'
+        }
+    },
+    'QUERY_TERMS': {
+        'terms': {
+            'field_name1': ['value_name1', 'value_name2'],
         }
     },
     'FILTER_MISSING': {
@@ -142,10 +148,10 @@ test('Filter.term', query, FILTERS['TERM'])
 query = Query.term(field_name1='value_name1')[2]
 test('Query.term', query, FILTERS['TERM'])
 
-query = Filter.terms(field_name1=['value_name1', 'value_name2'])[2]
-test('Filter.terms', query, FILTERS['TERMS'])
-query = Query.terms(field_name1=['value_name1', 'value_name2'])[2]
-test('Query.terms', query, FILTERS['TERMS'])
+query = Filter.terms(execution='bool', field_name1=['value_name1', 'value_name2'])[2]
+test('Filter.terms', query, FILTERS['FILTER_TERMS'])
+query = Query.terms(execution='bool', field_name1=['value_name1', 'value_name2'])[2]
+test('Query.terms', query, FILTERS['QUERY_TERMS'])
 
 query = Filter.missing('field_name1')[2]
 test('Filter.missing', query, FILTERS['FILTER_MISSING'])


### PR DESCRIPTION
Adding support for the `execution` [option](http://www.elastic.co/guide/en/elasticsearch/reference/1.4/query-dsl-terms-filter.html#_execution_mode) on Terms Filters.
