### PR TITLE
adding support for fuzzy like this and filtered queries

### DIFF
--- a/elasticquery/filter_query.py
+++ b/elasticquery/filter_query.py
@@ -5,12 +5,22 @@
 from datetime import datetime
 
 
+def inline_filter_query(filter_query):
+    return filter_query[2]
+
+
 def inline_filter_queries(filter_queries):
-    return [v[2] for v in filter_queries] if isinstance(filter_queries, list) else []
+    return [inline_filter_query(v) for v in filter_queries] if isinstance(filter_queries, list) else []
 
 
 class Filter(object):
     type = 'filter'
+
+    @classmethod
+    def match_all(self):
+        return self.type, [], {
+            'match_all': {}
+        }
 
     @classmethod
     def nested(self, path, must=None, should=None, must_not=None):
@@ -218,6 +228,32 @@ class Query(Filter):
                     }
                 }
             }
+        }
+
+    @classmethod
+    def filtered(self, query=None, filter=None):
+        settings = {}
+
+        if query is not None:
+            settings['query'] = inline_filter_query(query)
+
+        if filter is not None:
+            settings['filter'] = inline_filter_query(filter)
+
+        return self.type, [], {
+            'filtered': settings
+        }
+
+    @classmethod
+    def fuzzy_like_this(self, like_text, **kwargs):
+        settings = {
+            'like_text': like_text
+        }
+
+        settings.update(kwargs)
+
+        return self.type, [], {
+            'fuzzy_like_this': settings
         }
 
     @classmethod

--- a/test.py
+++ b/test.py
@@ -21,11 +21,16 @@ from elasticquery import ElasticQuery, Filter, Query, Aggregate
 
 # Some horrible helper functions
 test_count = {'count': 1}
+
+
 def error(message):
     print '\t[{0}] Error: {1}\n'.format(test_count['count'], message)
     sys.exit(1)
+
+
 def success(message):
     print '\t[{0}] Success: {1}'.format(test_count['count'], message)
+
 
 def test(name, got, want):
     if got != want:
@@ -127,6 +132,22 @@ FILTERS = {
                 }
             }
         }
+    },
+    'QUERY_FILTERED': {
+        'filtered': {
+            'filter': {
+                'match_all': {}
+            },
+            'query': {
+                'match_all': {}
+            }
+        }
+    },
+    'QUERY_FUZZY_LIKE_THIS': {
+        'fuzzy_like_this': {
+            'fields': ['name', 'foo'],
+            'like_text': 'test fuzzy'
+        }
     }
 }
 
@@ -170,6 +191,12 @@ test('Query.string', query, FILTERS['QUERY_STRING'])
 
 query = Filter.nested('nested_path', must=[Filter.term(field_name1='value_name1')])[2]
 test('Query.raw_string', query, FILTERS['NESTED_FILTER'])
+
+query = Query.filtered(query=Query.match_all(), filter=Filter.match_all())[2]
+test('Query.filtered', query, FILTERS['QUERY_FILTERED'])
+
+query = Query.fuzzy_like_this(like_text='test fuzzy', fields=['name', 'foo'])[2]
+test('Query.fuzzy_like_this', query, FILTERS['QUERY_FUZZY_LIKE_THIS'])
 
 
 # Aggregates:
@@ -313,9 +340,6 @@ QUERIES = {
                 }
             }
         },
-        'query': {
-            'match_all': {}
-        },
         'filter': {
             'bool': {
                 'must': [
@@ -332,10 +356,8 @@ QUERIES = {
                 'should': []
             }
         },
-        'sort': [],
-        'from':0,
+        'from': 0,
         'size': 10
-
     }
 }
 
@@ -345,7 +367,7 @@ query.must(Filter.range('field_name1', gte=0, lt=100))
 query.aggregate(Aggregate.terms('test_aggregate1', 'field_name1'))
 query.aggregate(Aggregate.stats('test_aggregate2', 'field_name2'))
 query.offset(0)
-query.limit(10)
+query.size(10)
 test('Full query: range + terms agg + stats agg', query.structure, QUERIES['RANGE_AGGTERMS_AGGSTATS'])
 
 


### PR DESCRIPTION
@Fizzadar this adds support for `fuzzy_like_this` and `filtered` queries and fixes the tests which were broken by your recent releases...
