### PR TITLE
Suggesters

### DIFF
--- a/docs/suggesters.md
+++ b/docs/suggesters.md
@@ -1,0 +1,50 @@
+# ElasticQuery Suggesters API
+
+Note that all Suggester calls can also be passed additional keyword arguments not specified here, but no validation of inputs is done on them.
+
++ [completion](#method-suggestercompletion)
++ [phrase](#method-suggesterphrase)
++ [term](#method-suggesterterm)
+
+### class: Suggester
+
+##### method: Suggester.completion
+
+```py
+Suggester.completion(
+    field,
+    s=None,
+    i=None,
+    z=None,
+    e=None
+)
+```
+
+##### method: Suggester.phrase
+
+```py
+Suggester.phrase(
+    field,
+    gram_size=None,
+    real_word_error_likelihood=None,
+    confidence=None,
+    max_errors=None,
+    separator=None,
+    size=None,
+    analyzer=None,
+    shard_size=None,
+    collate=None
+)
+```
+
+##### method: Suggester.term
+
+```py
+Suggester.term(
+    field,
+    analyzer=None,
+    size=None,
+    sort=None,
+    suggest_mode=None
+)
+```

--- a/docs/suggesters.md
+++ b/docs/suggesters.md
@@ -13,10 +13,7 @@ Note that all Suggester calls can also be passed additional keyword arguments no
 ```py
 Suggester.completion(
     field,
-    s=None,
-    i=None,
-    z=None,
-    e=None
+    size=None
 )
 ```
 

--- a/elasticquery/__init__.py
+++ b/elasticquery/__init__.py
@@ -4,3 +4,4 @@ from .elasticquery import ElasticQuery
 from .filters import Filter
 from .queries import Query
 from .aggregates import Aggregate
+from .suggesters import Suggester

--- a/elasticquery/dsl.py
+++ b/elasticquery/dsl.py
@@ -134,7 +134,3 @@ class BaseSuggester(BaseFilterQuery):
                 struct.update(sugg.dict())
 
         return struct
-
-    def suggest(self, *suggesters):
-        self._suggs.extend(suggesters)
-        return self

--- a/elasticquery/dsl.py
+++ b/elasticquery/dsl.py
@@ -41,6 +41,21 @@ class MetaAggregate(MetaFilterQuery):
             make_struct(cls._definitions[key], *args[1:], **kwargs)
         )
 
+class MetaSuggester(MetaFilterQuery):
+    '''Modified MetaFilterQuery.MetaSuggester getattr to handle suggester names and text.'''
+    def __getattr__(cls, key):
+        if key == '__test__':
+            return None
+
+        if key not in cls._definitions:
+            raise cls._exception(key)
+
+        return lambda *args, **kwargs: cls(
+            key,
+            args[0],
+            args[1],
+            make_struct(cls._definitions[key], *args[2:], **kwargs)
+        )
 
 class BaseFilterQuery(object):
     '''The base class which represents a Filter/Query struct.'''
@@ -92,4 +107,34 @@ class BaseAggregate(BaseFilterQuery):
 
     def aggregate(self, *aggregates):
         self._aggs.extend(aggregates)
+        return self
+
+class BaseSuggester(BaseFilterQuery):
+    '''Modified BaseFilterQuery to handle suggester name & text storage.'''
+    _name = None
+
+    def __init__(self, dsl_type, name, text, struct):
+        self._dsl_type = dsl_type
+        self._struct = struct
+        self._name = name
+        self._text = text
+
+        self._suggs = []
+
+    def dict(self):
+        struct = {
+            self._name: {
+                "text": self._text,
+                self._dsl_type: unroll_struct(self._struct)
+            }
+        }
+
+        if self._suggs:
+            for sugg in self._suggs:
+                struct.update(sugg.dict())
+
+        return struct
+
+    def suggest(self, *suggesters):
+        self._suggs.extend(suggesters)
         return self

--- a/elasticquery/elasticquery.py
+++ b/elasticquery/elasticquery.py
@@ -30,6 +30,7 @@ class ElasticQuery(object):
         self._doc_type = doc_type
 
         self._aggs = []
+        self._suggesters = []
 
         # An empty query
         self._struct = {}
@@ -42,6 +43,9 @@ class ElasticQuery(object):
 
     def aggregate(self, *aggregates):
         self._aggs.extend(aggregates)
+
+    def suggest(self, *suggesters):
+        self._suggesters.extend(suggesters)
 
     def set(self, key, value):
         '''Set an arbitrary attribute on this query.'''
@@ -98,6 +102,13 @@ class ElasticQuery(object):
                 aggs.update(agg.dict())
 
             self._struct['aggregations'] = aggs
+
+        if self._suggesters:
+            suggs = {}
+            for sugg in self._suggesters:
+                suggs.update(sugg.dict())
+
+            self._struct['suggest'] = suggs
 
         return unroll_struct(self._struct)
 

--- a/elasticquery/exception.py
+++ b/elasticquery/exception.py
@@ -32,6 +32,9 @@ class NoFilter(DslException):
 class NoAggregate(DslException):
     pass
 
+class NoSuggester(DslException):
+    pass
+
 
 # Invalid DSL argument exceptions
 class InvalidArg(DslException):

--- a/elasticquery/suggesters.py
+++ b/elasticquery/suggesters.py
@@ -12,12 +12,14 @@ SUGGESTERS = {
     },
     'phrase': {
         'args': ('field', ),
-        'kwargs': ('gram_size', 'real_word_error_likelihood', 'confidence', 'max_errors',
-                'separator', 'size', 'analyzer', 'shard_size', 'collate')
+        'kwargs': (
+            'gram_size', 'real_word_error_likelihood', 'confidence', 'max_errors',
+            'separator', 'size', 'analyzer', 'shard_size', 'collate'
+        )
     },
     'completion': {
         'args': ('field', ),
-        'kwargs': ('size')
+        'kwargs': ('size', )
     }
 }
 

--- a/elasticquery/suggesters.py
+++ b/elasticquery/suggesters.py
@@ -1,0 +1,29 @@
+# ElasticQuery
+# File: elasticquery/suggesters.py
+# Desc: internal ElasticQuery definitions mapping to Elasticsearch suggester objects
+
+from .dsl import BaseSuggester, MetaSuggester
+from .exception import NoSuggester
+
+SUGGESTERS = {
+    'term': {
+        'args': ('field', ),
+        'kwargs': ('analyzer', 'size', 'sort', 'suggest_mode')
+    },
+    'phrase': {
+        'args': ('field', ),
+        'kwargs': ('gram_size', 'real_word_error_likelihood', 'confidence', 'max_errors',
+                'separator', 'size', 'analyzer', 'shard_size', 'collate')
+    },
+    'completion': {
+        'args': ('field', ),
+        'kwargs': ('size')
+    }
+}
+
+class Suggester(BaseSuggester):
+    __metaclass__ = MetaSuggester
+
+    _eq_type = 'suggester'
+    _definitions = SUGGESTERS
+    _exception = NoSuggester

--- a/scripts/build_docs.py
+++ b/scripts/build_docs.py
@@ -7,6 +7,7 @@
 from elasticquery.aggregates import AGGREGATES
 from elasticquery.filters import FILTERS
 from elasticquery.queries import QUERIES
+from elasticquery.suggesters import SUGGESTERS
 
 STRING_TO_CLASS = {
     '_query': 'Query',
@@ -106,5 +107,6 @@ Note that all {1} calls can also be passed additional keyword arguments not spec
 build_dsl_docs(AGGREGATES, 'Aggregates', 'Aggregate', 'docs/aggregates.md')
 build_dsl_docs(FILTERS, 'Filters', 'Filter', 'docs/filters.md')
 build_dsl_docs(QUERIES, 'Queries', 'Query', 'docs/queries.md')
+build_dsl_docs(SUGGESTERS, 'Suggesters', 'Suggester', 'docs/suggesters.md')
 
 print 'Docs built!'

--- a/tests/suggesters/completion.json
+++ b/tests/suggesters/completion.json
@@ -1,0 +1,19 @@
+{
+    "args": ["sugg_name", "term_text", "term_field"],
+    "kwargs": {
+        "fuzzy" : {
+            "fuzziness" : 2
+        }
+    },
+    "output": {
+        "sugg_name": {
+            "text": "term_text",
+            "completion": {
+                "field": "term_field",
+                "fuzzy" : {
+                    "fuzziness" : 2
+                }
+            }
+        }
+    }
+}

--- a/tests/suggesters/phrase.json
+++ b/tests/suggesters/phrase.json
@@ -1,0 +1,25 @@
+{
+    "args": ["sugg_name", "term_text", "term_field"],
+    "kwargs": {
+        "size": 1,
+        "real_word_error_likelihood": 0.95,
+        "highlight": {
+          "pre_tag": "<em>",
+          "post_tag": "</em>"
+        }
+    },
+    "output": {
+        "sugg_name": {
+            "text": "term_text",
+            "phrase": {
+                "field": "term_field",
+                "size": 1,
+                "real_word_error_likelihood": 0.95,
+                "highlight": {
+                  "pre_tag": "<em>",
+                  "post_tag": "</em>"
+                }
+            }
+        }
+    }
+}

--- a/tests/suggesters/term.json
+++ b/tests/suggesters/term.json
@@ -1,0 +1,15 @@
+{
+    "args": ["sugg_name", "term_text", "term_field"],
+    "kwargs": {
+        "size": 3
+    },
+    "output": {
+        "sugg_name": {
+            "text": "term_text",
+            "term": {
+                "field": "term_field",
+                "size": 3
+            }
+        }
+    }
+}

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -7,7 +7,7 @@ from unittest import TestCase
 
 from jsontest import JsonTest
 
-from elasticquery import Filter, Query, Aggregate
+from elasticquery import Filter, Query, Aggregate, Suggester
 from .util import assert_equal
 
 CLASS_NAMES = {
@@ -60,6 +60,14 @@ class TestAggregates(TestCase):
     jsontest_files = path.join('tests', 'aggregates')
     jsontest_function = lambda self, test_name, test_data: (
         _test_filterquery(self, Aggregate, test_name, test_data)
+    )
+
+class TestSuggesters(TestCase):
+    __metaclass__ = JsonTest
+
+    jsontest_files = path.join('tests', 'suggesters')
+    jsontest_function = lambda self, test_name, test_data: (
+        _test_filterquery(self, Suggester, test_name, test_data)
     )
 
 class TestQueryFilter(TestCase):


### PR DESCRIPTION
Hi @Fizzadar!

This adds support for Suggesters. I've taken the list from [here](https://www.elastic.co/guide/en/elasticsearch/reference/1.7/search-suggesters.html). The tests and docs have also been updated.

The format of suggesters is a little bit different from aggregates so the format of the returned dicts is a little different. One thing I'm unsure about is the naming of `suggest()` inside the `BaseSuggester` - it is used for chaining suggesters together (examples in the ES docs link). This is slightly different to `aggregate()` in `BaseAggregate` which does a sub aggregation - don't know whether the name may be misleading and something like `chain` might be clearer!
