### PR TITLE
fixed pip install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ print q.get()
 ## Development/Testing
 
 + Create virtualenv
-+ `pip install requirements.pip`
++ `pip install -r requirements.pip`
 + Run `nosetests`


### PR DESCRIPTION
The original command produces this error:

```
$ pip install requirements.pip
Collecting requirements.pip
  Could not find a version that satisfies the requirement requirements.pip (from versions: )
No matching distribution found for requirements.pip
```